### PR TITLE
chore: stop ignoring vercel config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ xproc/stores/
 /xproc/config
 tei/odd
 tei/stylesheet
-.vercel


### PR DESCRIPTION
- allow committing .vercel for deployment setup
