### PR TITLE
ci(release): generate releases index from tags

### DIFF
--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -343,6 +343,7 @@ jobs:
         run: |
           set -euo pipefail
           git fetch origin main
+          git fetch --tags --force
           if [ "$(git cat-file -t "${GITHUB_REF_NAME}")" != "tag" ]; then
             echo "Tag ${GITHUB_REF_NAME} is not annotated."
             exit 1
@@ -433,6 +434,8 @@ jobs:
         run: |
           set -euo pipefail
           RELEASE_TAG="${GITHUB_REF_NAME}"
+          RELEASE_TAGS="$(git tag --list 'v*' --sort=-version:refname)"
+          export RELEASE_TAGS
           mkdir -p .deploy-pages
           cd .deploy-pages
           git init
@@ -459,28 +462,3 @@ jobs:
           fi
           git commit -m "Publish ${RELEASE_TAG}"
           git push origin gh-pages
-      - name: Update RELEASES.md on main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          RELEASE_TAG="${GITHUB_REF_NAME}"
-          TMPDIR="$(mktemp -d)"
-          git clone --branch main "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$TMPDIR"
-          cd "$TMPDIR"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          RELEASES_FILE="RELEASES.md"
-          URL="https://lex0.org/releases/${RELEASE_TAG}/"
-          if [ ! -f "$RELEASES_FILE" ]; then
-            echo "# Releases" > "$RELEASES_FILE"
-            echo "" >> "$RELEASES_FILE"
-          fi
-          if grep -q "$URL" "$RELEASES_FILE"; then
-            echo "Release already listed."
-            exit 0
-          fi
-          echo "- ${RELEASE_TAG}: ${URL}" >> "$RELEASES_FILE"
-          git add "$RELEASES_FILE"
-          git commit -m "Add ${RELEASE_TAG} release URL"
-          git push origin main

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -92,8 +92,7 @@ Publishing rules:
 - Clean destination branches before copying to avoid stale files.
 - Append commits when publishing to `vercel-main` and `vercel-dev`.
 - For tags, fail if the release folder already exists.
-- `releases/index.html` is generated in the tag workflow on `gh-pages`.
-- `RELEASES.md` in `main` is updated only after a successful tag publish.
+- `releases/index.html` in `gh-pages` is regenerated on every successful tag publish.
 
 ## Release banner behavior
 

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -7,7 +7,7 @@ Goal: keep `dev` and `main` strictly linear with rebase-only PR merges, publish 
 - Set up [required settings](#required-github-settings) on GitHub
 - **Publish to dev site:** merge PRs into `dev` (rebase-only) → pushing to `dev` triggers deployment to `dev.lex0.org`.
 - **Publish to production site:** fast-forward `main` to `dev` → pushing to `main` triggers deployment to `lex0.org`.
-- **Publish an immutable release:** create an **annotated** tag `vX.Y.Z` on `main` and push the tag → GitHub Actions publishes to `gh-pages/releases/vX.Y.Z/` and updates `RELEASES.md`.
+- **Publish an immutable release:** create an **annotated** tag `vX.Y.Z` on `main` and push the tag → GitHub Actions publishes to `gh-pages/releases/vX.Y.Z/` and updates the releases index on `gh-pages`.
 
 ## Feature branch creation
 
@@ -63,7 +63,6 @@ Releases are immutable snapshots published under `lex0.org/releases/vX.Y.Z/` (Gi
 
    - Publishes `build/html` to `gh-pages/releases/vX.Y.Z/`
    - Regenerates `gh-pages/releases/index.html`
-   - Appends the release URL to `RELEASES.md` on `main`
 
 5. Verify:
 


### PR DESCRIPTION
Phase A: keep `main` fast-forward-only from `dev` by removing the tag workflow step that writes `RELEASES.md` to `main`.

- Tag workflow now generates `gh-pages/releases/index.html` from git tags.
- `scripts/generate-release-index.cjs` prefers tag list (env `RELEASE_TAGS` / `git tag`) with directory fallback.
- Docs updated to match.
