### PR TITLE
ci(vercel): include vercel.json in deploy branches

### DIFF
--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -201,6 +201,7 @@ jobs:
             git checkout -B "$TARGET_BRANCH"
           fi
           cp -R ../build/html/. .
+          cp ../vercel.json ./vercel.json
           git add .
           if git diff --cached --quiet; then
             echo "No changes to publish."
@@ -314,6 +315,7 @@ jobs:
             git checkout -B "$TARGET_BRANCH"
           fi
           cp -R ../build/html/. .
+          cp ../vercel.json ./vercel.json
           git add .
           if git diff --cached --quiet; then
             echo "No changes to publish."


### PR DESCRIPTION
Ensures Vercel rewrites (e.g. `/releases/*`) are present in the deployed `vercel-main`/`vercel-dev` branches.

The CI deploy steps previously copied only `build/html` output, so `vercel.json` was missing from the deployment branch and routes like `https://lex0.org/releases/...` returned a Vercel 404.
