### PR TITLE
fix(vercel): trailing-slash releases routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,20 @@
 {
+  "redirects": [
+    {
+      "source": "/releases",
+      "destination": "/releases/",
+      "permanent": true
+    }
+  ],
   "rewrites": [
+    {
+      "source": "/releases/",
+      "destination": "https://bcdh.github.io/tei-lex-0/releases/"
+    },
+    {
+      "source": "/releases/:path*/",
+      "destination": "https://bcdh.github.io/tei-lex-0/releases/:path*/"
+    },
     {
       "source": "/releases/:path*",
       "destination": "https://bcdh.github.io/tei-lex-0/releases/:path*"


### PR DESCRIPTION
Fixes `https://lex0.org/releases/...` routing so the releases index resolves links correctly.

- Redirects `/releases` -> `/releases/` (so relative links like `v0.9.4/` stay under `/releases/`).
- Adds explicit rewrites for `/releases/` and `/releases/:path*/`.
