### PR TITLE
feat(build): add sitemap-aware build outputs

### DIFF
--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Link hygiene
         run: node scripts/check-internal-links.mjs
       - name: Post-process HTML
-        run: node scripts/postprocess-html.mjs --mode=main
+        run: node scripts/postprocess-html.mjs --mode=main --sitemap=main
       - name: Publish to vercel-main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -318,7 +318,7 @@ jobs:
       - name: Link hygiene
         run: node scripts/check-internal-links.mjs
       - name: Post-process HTML
-        run: node scripts/postprocess-html.mjs --mode=dev
+        run: node scripts/postprocess-html.mjs --mode=dev --sitemap=dev
       - name: Publish to vercel-dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/assets/js/algo.js
+++ b/assets/js/algo.js
@@ -1,9 +1,30 @@
+const DOCSEARCH_CONFIG = {
+  appId: "7KP0FJOR6F",
+  apiKey: "c30c21b1f89a0e2d5b44df1be7401072",
+  indexProd: "lex0-crawler",
+  indexDev: "lex0-dev-crawler",
+};
+
+const selectIndexName = () => {
+  if (window.location.protocol === "file:") return DOCSEARCH_CONFIG.indexDev;
+  const host = window.location.hostname || "";
+  if (host === "dev.lex-0.org" || host.startsWith("dev.")) {
+    return DOCSEARCH_CONFIG.indexDev;
+  }
+  if (host === "localhost" || host === "127.0.0.1") {
+    return DOCSEARCH_CONFIG.indexDev;
+  }
+  return DOCSEARCH_CONFIG.indexProd;
+};
+
 (() => {
   const docsearchFn = window.docsearch;
   if (typeof docsearchFn !== "function") {
     // DocSearch UMD script not loaded.
     return;
   }
+
+  const indexName = selectIndexName();
 
   // DocSearch can sometimes leave the "kbd pressed" visual state stuck
   // (e.g. ⌘ / Ctrl keycap shows as pressed) if the corresponding keyup event
@@ -43,7 +64,10 @@
     if (typeof itemUrl !== "string") return itemUrl;
 
     const isLex0Host = (hostname) =>
-      hostname === "lex-0.org" || hostname.endsWith(".lex-0.org");
+      hostname === "lex-0.org" ||
+      hostname.endsWith(".lex-0.org") ||
+      hostname === "lex0.org" ||
+      hostname.endsWith(".lex0.org");
 
     let parsed;
     try {
@@ -75,9 +99,9 @@
   };
 
   docsearchFn({
-    appId: "7KP0FJOR6F",
-    apiKey: "c30c21b1f89a0e2d5b44df1be7401072",
-    indexName: "lex0-crawler",
+    appId: DOCSEARCH_CONFIG.appId,
+    apiKey: DOCSEARCH_CONFIG.apiKey,
+    indexName,
     container: "#docsearch",
     transformItems(items) {
       return (items || []).map((item) => {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -81,6 +81,15 @@ Modes:
 - `dev`: noindex; `robots.txt` disallows all; no sitemap.
 - `release`: noindex; `robots.txt` disallows all; no sitemap.
 
+Sitemap flag:
+
+- `--sitemap=main|dev|none` overrides the sitemap output for a given mode.
+- `--mode=main` defaults to `--sitemap=main`; `--mode=dev` defaults to `--sitemap=dev`; `--mode=release` defaults to `--sitemap=none`.
+
+Algolia config:
+
+- Index selection is based on hostname (prod vs dev vs local).
+
 ### Publishing targets
 
 - `main` build -> `vercel-main` (repo root).

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "npm run assets:odd && npm run assets:minify && npm run assets:images",
     "assets:watch": "node scripts/watch-assets.mjs",
     "postprocess:html": "node scripts/postprocess-html.mjs",
+    "postprocess:html:dev": "node scripts/postprocess-html.mjs --mode=dev --sitemap=dev",
     "links:check": "node scripts/check-internal-links.mjs",
     "postprocess:watch": "node scripts/watch-postprocess-script.mjs",
     "releases:index": "node scripts/generate-release-index.cjs"


### PR DESCRIPTION
- extend postprocess script with sitemap selection
- wire workflows, docs, npm script to new sitemap flag
- auto-select Algolia index based on current hostname
