### PR TITLE
ci: handle citation file without stash

### DIFF
--- a/.github/workflows/citation-metadata.yml
+++ b/.github/workflows/citation-metadata.yml
@@ -105,20 +105,15 @@ jobs:
           BASE="${GITHUB_REF_NAME}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          STASHED=0
-          if [ -n "$(git status --porcelain CITATION.cff)" ]; then
-            git stash push -u -m "citation-metadata" -- CITATION.cff
-            STASHED=1
-          fi
+          TMP_CFF="$(mktemp)"
+          cp CITATION.cff "$TMP_CFF"
           git fetch origin "$BRANCH" || true
           if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
             git checkout -B "$BRANCH" "origin/$BRANCH"
           else
             git checkout -B "$BRANCH"
           fi
-          if [ "$STASHED" = "1" ]; then
-            git stash pop
-          fi
+          mv "$TMP_CFF" CITATION.cff
           git add CITATION.cff
           git commit -m "chore: update citation metadata"
           git push --force-with-lease -u origin "$BRANCH"


### PR DESCRIPTION
- copy CITATION.cff to tmp file to drop stash usage
- restore file via mv so git stash is no longer needed
