### PR TITLE
fix citation metadata

### DIFF
--- a/.github/workflows/citation-metadata.yml
+++ b/.github/workflows/citation-metadata.yml
@@ -140,8 +140,12 @@ jobs:
               PR_NUMBER="$(gh pr view --head "$BRANCH" --base "$BASE" --json number --jq '.number' 2>/dev/null || true)"
             fi
             if [ -z "$PR_NUMBER" ]; then
-              echo "Unable to determine PR number after create. PR_URL='$PR_URL'"
-              exit 1
+              if [ -n "$PR_URL" ]; then
+                echo "Warning: unable to determine PR number; will use PR URL."
+              else
+                echo "Unable to determine PR number after create. PR_URL='$PR_URL'"
+                exit 1
+              fi
             fi
           else
             PR_URL=""


### PR DESCRIPTION
- **fix: use PR ref fallback in citation workflow**
  

- **fix: guard missing PR number in workflow**
  - log warning when only PR URL is available
  - keep error path when both number and URL are absent
  