### PR TITLE
fix: make release-helper PR-based and rerun-safe

### DIFF
--- a/.github/workflows/release-helper.yml
+++ b/.github/workflows/release-helper.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
+      actions: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -69,16 +71,76 @@ jobs:
             fi
             exit 1
           fi
-      - name: Fast-forward main to dev
+      - name: Open promotion PR (dev -> main)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if ! git merge-base --is-ancestor origin/main origin/dev; then
-            echo "origin/main and origin/dev have diverged (not fast-forwardable)."
+          if git merge-base --is-ancestor origin/main origin/dev; then
+            NEED_PROMOTION=1
+          elif git merge-base --is-ancestor origin/dev origin/main; then
+            NEED_PROMOTION=0
+            echo "origin/main already contains origin/dev; skipping promotion PR."
+          else
+            echo "origin/main and origin/dev have diverged (not rebase-promotable)."
             exit 1
           fi
-          git checkout main
-          git merge --ff-only origin/dev
-          git push origin main
+
+          if [ "$NEED_PROMOTION" -eq 0 ]; then
+            echo "PROMOTION_PR_URL=" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          TAG="${{ inputs.tag }}"
+          RELEASE_BRANCH="ci/release-helper/${TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git checkout -B "$RELEASE_BRANCH" origin/dev
+          git push origin "$RELEASE_BRANCH"
+          PR_TITLE="chore(release): promote dev to main for ${TAG}"
+          PR_BODY="Automated release-helper PR to promote dev to main before tagging ${TAG}."
+          PR_URL="$(gh pr create --base main --head "$RELEASE_BRANCH" --title "$PR_TITLE" --body "$PR_BODY" 2>/dev/null || true)"
+          if [ -z "$PR_URL" ]; then
+            PR_URL="$(gh pr view --head "$RELEASE_BRANCH" --base main --json url --jq '.url' 2>/dev/null || true)"
+          fi
+          if [ -z "$PR_URL" ]; then
+            echo "Unable to create or resolve promotion PR for head '$RELEASE_BRANCH'."
+            exit 1
+          fi
+          gh pr merge "$PR_URL" --auto --rebase
+          echo "PROMOTION_PR_URL=$PR_URL" >> "$GITHUB_ENV"
+      - name: Wait for promotion PR merge
+        if: ${{ env.PROMOTION_PR_URL != '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR_URL="${PROMOTION_PR_URL}"
+          if [ -z "$PR_URL" ]; then
+            echo "Promotion PR URL missing."
+            exit 1
+          fi
+          echo "Waiting for PR to merge: $PR_URL"
+          for i in $(seq 1 180); do
+            merged_at="$(gh pr view "$PR_URL" --json mergedAt --jq '.mergedAt')"
+            state="$(gh pr view "$PR_URL" --json state --jq '.state')"
+            if [ "$merged_at" != "null" ] && [ -n "$merged_at" ]; then
+              break
+            fi
+            if [ "$state" = "CLOSED" ]; then
+              echo "Promotion PR closed without merge: $PR_URL"
+              exit 1
+            fi
+            sleep 10
+          done
+          merged_at="$(gh pr view "$PR_URL" --json mergedAt --jq '.mergedAt')"
+          if [ "$merged_at" = "null" ] || [ -z "$merged_at" ]; then
+            echo "Timed out waiting for promotion PR merge: $PR_URL"
+            exit 1
+          fi
+          git fetch origin main dev --tags
+          if ! git merge-base --is-ancestor origin/dev origin/main; then
+            echo "After PR merge, origin/main does not contain origin/dev."
+            exit 1
+          fi
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -145,6 +207,14 @@ jobs:
           CALABASH_CP="$(cat "$OUTPUT_FILE")"
           echo "XMLCALABASH_CMD=java -cp \"$CALABASH_CP\" com.xmlcalabash.app.Main {PIPELINE}" >> "$GITHUB_ENV"
           echo "SAXON_JAR=$SAXON_JAR" >> "$GITHUB_ENV"
+      - name: Checkout citation branch from main
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag }}"
+          CITATION_BRANCH="ci/release-citation/${TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git fetch origin main --tags
+          git checkout -B "$CITATION_BRANCH" origin/main
+          echo "CITATION_BRANCH=$CITATION_BRANCH" >> "$GITHUB_ENV"
       - run: node scripts/run-citation-cff.mjs
       - name: Inject citation metadata
         run: |
@@ -154,22 +224,67 @@ jobs:
             --date "$(date -u +%F)" \
             --date-released "$(date -u +%F)"
       - name: Commit citation metadata
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          TAG="${{ inputs.tag }}"
           if git diff --quiet -- CITATION.cff; then
             echo "No citation metadata changes."
+            echo "CITATION_PR_URL=" >> "$GITHUB_ENV"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add CITATION.cff
           git commit -m "chore: update citation metadata"
-          git push origin main
+          git push origin "$CITATION_BRANCH"
+          PR_TITLE="chore(release): citation metadata for ${TAG}"
+          PR_BODY="Automated release-helper PR to add release citation metadata before tagging ${TAG}."
+          PR_URL="$(gh pr create --base main --head "$CITATION_BRANCH" --title "$PR_TITLE" --body "$PR_BODY" 2>/dev/null || true)"
+          if [ -z "$PR_URL" ]; then
+            PR_URL="$(gh pr view --head "$CITATION_BRANCH" --base main --json url --jq '.url' 2>/dev/null || true)"
+          fi
+          if [ -z "$PR_URL" ]; then
+            echo "Unable to create or resolve citation metadata PR for head '$CITATION_BRANCH'."
+            exit 1
+          fi
+          gh pr merge "$PR_URL" --auto --rebase
+          echo "CITATION_PR_URL=$PR_URL" >> "$GITHUB_ENV"
+      - name: Wait for citation metadata PR merge
+        if: ${{ env.CITATION_PR_URL != '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR_URL="${CITATION_PR_URL}"
+          echo "Waiting for PR to merge: $PR_URL"
+          for i in $(seq 1 180); do
+            merged_at="$(gh pr view "$PR_URL" --json mergedAt --jq '.mergedAt')"
+            state="$(gh pr view "$PR_URL" --json state --jq '.state')"
+            if [ "$merged_at" != "null" ] && [ -n "$merged_at" ]; then
+              break
+            fi
+            if [ "$state" = "CLOSED" ]; then
+              echo "Citation metadata PR closed without merge: $PR_URL"
+              exit 1
+            fi
+            sleep 10
+          done
+          merged_at="$(gh pr view "$PR_URL" --json mergedAt --jq '.mergedAt')"
+          if [ "$merged_at" = "null" ] || [ -z "$merged_at" ]; then
+            echo "Timed out waiting for citation metadata PR merge: $PR_URL"
+            exit 1
+          fi
       - name: Create annotated tag
         run: |
           set -euo pipefail
           TAG="${{ inputs.tag }}"
           git fetch origin main --tags
-          git checkout main
+          git checkout -B main origin/main
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag already exists after PR merge stage: $TAG"
+            exit 1
+          fi
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"

--- a/docs/cff.md
+++ b/docs/cff.md
@@ -60,9 +60,9 @@ If the secret is missing, the workflow fails fast with a clear error.
 - `site-build` (push to `dev`/`main` and tags)
   - Skips deploy on metadata-only bot commits
 - `release-helper` (manual, owner-only)
-  - Fast-forwards `main` to `dev`
+  - Opens a PR to promote `dev` to `main` (no direct push)
   - Regenerates `CITATION.cff`
-  - Injects `commit` + `date-generated` + `date-released` and commits
+  - Opens a PR that injects `commit` + `date-generated` + `date-released`
   - Creates the annotated tag
 
 ## Release Notes

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -52,14 +52,21 @@ Releases are immutable snapshots published under `lex-0.org/releases/vX.Y.Z/` (G
 
 Use the GitHub Actions **release-helper** workflow (`.github/workflows/release-helper.yml`, manual trigger). It is gated to `ttasovac` and:
 
-- fast-forwards `main` to `dev` (ff-only)
+- opens a PR to promote `dev` to `main` and waits for merge
 - regenerates `CITATION.cff`
-- injects metadata (`commit`, `date-generated`, `date-released`) and commits it to `main`
+- opens a PR with citation metadata (`commit`, `date-generated`, `date-released`) and waits for merge
 - creates an annotated tag `vX.Y.Z`
 
 Then the normal tag build publishes to `gh-pages/releases/vX.Y.Z/`.
 
+Reruns: `release-helper` is rerun-safe. If `main` already contains `dev`, it
+skips the promotion PR. For release-helper-created branches, it reuses the
+existing PR when possible instead of failing on duplicate PR creation.
+
 ### Release process (manual alternative)
+
+This path assumes your `main` rules allow the required direct push operation. If
+`main` is PR-only, use `release-helper`.
 
 1. Fast-forward `main` to `dev` (see [above](#release-dev-to-main-ff-only).)
 2. Wait for GitHub Actions → `citation-metadata` (`.github/workflows/citation-metadata.yml`) on `main` to open and auto-merge the metadata PR.
@@ -115,9 +122,9 @@ Use two rulesets, because `dev` and `main` have different constraints.
   - Enable: “Require linear history”
   - Enable: “Block force pushes” and “Block deletions”
   - Required status checks: `check_citation` and `pr` (build-site)
-- **Ruleset for `main` (FF-only by admin):**
+- **Ruleset for `main` (release-helper PR-based):**
   - Target branches (fnmatch pattern): `main`
-  - Enable: “Require a pull request before merging” (it blocks the `git merge --ff-only origin/dev && git push origin main` release step)
+  - Enable: “Require a pull request before merging” (release-helper now opens PRs instead of pushing directly)
   - Enable: “Require linear history”
   - Enable: “Block force pushes” and “Block deletions”
   - Required status checks: `check_citation` and `pr` (build-site)


### PR DESCRIPTION
- Promotion and citation steps now open/merge PRs before tagging
- Docs describe rerun behavior and PR requirements
