### PR TITLE
chore: gate citation workflow to manual use

### DIFF
--- a/.github/workflows/citation-metadata.yml
+++ b/.github/workflows/citation-metadata.yml
@@ -1,8 +1,7 @@
 name: citation-metadata
 
 on:
-  push:
-    branches: [dev]
+  workflow_dispatch:
 
 concurrency:
   group: citation-metadata-${{ github.ref }}

--- a/docs/cff.md
+++ b/docs/cff.md
@@ -41,20 +41,15 @@ provenance metadata.
 
 ### Secrets and permissions
 
-The `citation-metadata` workflow must create a PR that triggers PR checks. To
-avoid the GitHub Actions token suppression on `pull_request` workflows, it uses
-a fine-grained PAT stored as a repo secret:
+Primary release prep is done via `npm run release:prepare` using the maintainer
+identity (no bot PAT required).
 
-- **Secret name:** `CITATION_BOT_TOKEN`
-- **Resource owner:** `BCDH`
-- **Repository access:** only `BCDH/tei-lex-0`
-- **Permissions:** Contents (read/write), Pull requests (read/write), Actions (read/write)
-
-If the secret is missing, the workflow fails fast with a clear error.
+`CITATION_BOT_TOKEN` is only needed if you explicitly run the legacy/manual
+`citation-metadata` workflow.
 
 ## CI Workflows
 
-- `citation-metadata` (push to `dev`)
+- `citation-metadata` (manual fallback via `workflow_dispatch`)
   - Runs the citation-only pipeline (`xproc/citation-cff.xpl`)
   - Injects `commit` + `date-generated`
   - Opens/updates a PR and enables auto-merge (no direct pushes)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -52,7 +52,7 @@ All deployments are handled in GitHub Actions. High-level triggers:
 - Pull requests targeting `dev`: build only; no post-processing; no publish.
 - Pushes to `main` and `dev`: build + post-process, then publish to Vercel artifact branches.
 - **Annotated tags** on `main` (e.g., `vX.Y.Z`): build + post-process, then publish to GitHub Pages.
-- Metadata generation for `CITATION.cff` happens in a separate workflow on pushes to `dev` (`.github/workflows/citation-metadata.yml`).
+- Release metadata for `CITATION.cff` is prepared explicitly during release prep (`npm run release:prepare`), not on every `dev` push.
 - `citation-check` runs on PRs to `dev`/`main`; in branch protection, `dev` currently requires `check_citation` and `pr`.
 
 Common job steps:

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -92,7 +92,7 @@ Then the normal tag build publishes to `gh-pages/releases/vX.Y.Z/`.
    - `git push -u origin chore/release-prep-vX.Y.Z`
    - `gh pr create --base dev --head chore/release-prep-vX.Y.Z --title "chore: prepare citation metadata for vX.Y.Z" --body ""`
    - `gh pr merge --rebase --auto`
-2. Wait for GitHub Actions → `citation-metadata` and `build-site` on `dev` to finish successfully.
+2. Wait for GitHub Actions → `build-site` on `dev` to finish successfully.
 3. Fast-forward `main` to `dev` (see [above](#release-dev-to-main-ff-only).)
 4. Wait for GitHub Actions → `build-site` on `main` to finish successfully (this deploys `lex-0.org`).
 5. Create an **annotated** tag on `main` and push it:
@@ -125,15 +125,15 @@ These settings enforce a rebase-only workflow on `dev`, while still allowing adm
 
 **Repo settings → Secrets and variables → Actions**
 
-- `CITATION_BOT_TOKEN` (fine-grained PAT) is required for the `citation-metadata`
-  workflow to open PRs that trigger PR checks.
+- `CITATION_BOT_TOKEN` is optional now (used only if you run the legacy/manual
+  `citation-metadata` workflow directly).
 
 **Repo settings → Pull Requests**
 
 - Enable: “Allow rebase merging”
 - Disable: “Allow merge commits”
 - Disable: “Allow squash merging” (rebase-only)
-- Enable: “Allow auto-merge” (required for `citation-metadata` PRs)
+- Enable: “Allow auto-merge” (required for automated release-prep PR merges)
 - Do _not_ set “Always suggest updating pull request branches” (the “Update branch” flow is not compatible with rebase-only workflows)
 
 **Repo settings → Rules → Rulesets**


### PR DESCRIPTION
- Switch citation-metadata workflow to workflow_dispatch
- Document release prep now handles CITATION.cff updates
- Adjust release doctor checks and secret guidance
