### PR TITLE
ci(release): push tags with CITATION_BOT_TOKEN

### DIFF
--- a/.github/workflows/release-helper.yml
+++ b/.github/workflows/release-helper.yml
@@ -89,9 +89,16 @@ jobs:
             exit 1
           fi
       - name: Create annotated tag
+        env:
+          TAG_PUSH_TOKEN: ${{ secrets.CITATION_BOT_TOKEN }}
         run: |
           set -euo pipefail
+          if [ -z "${TAG_PUSH_TOKEN:-}" ]; then
+            echo "Missing secret: CITATION_BOT_TOKEN"
+            exit 1
+          fi
           TAG="${{ inputs.tag }}"
+          git remote set-url origin "https://x-access-token:${TAG_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git fetch origin main --tags
           git checkout -B main origin/main
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
Use `CITATION_BOT_TOKEN` for release tag push in `release-helper`.

## Changes
- add explicit secret check for `CITATION_BOT_TOKEN`
- set authenticated `origin` URL with that token before `git push origin <tag>`

## Why
Tag pushes created via default `GITHUB_TOKEN` can fail to trigger downstream workflows reliably. Using `CITATION_BOT_TOKEN` keeps tag-driven release publication deterministic.
