### PR TITLE
separate schemas in releases

### DIFF
--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -96,6 +96,105 @@ jobs:
       - name: Link hygiene
         run: node scripts/check-internal-links.mjs
 
+  archive_smoke:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Cache Calabash, Saxon, and Maven
+        uses: actions/cache@v4
+        with:
+          path: |
+            .cache/tools
+            ~/.m2/repository
+          key: calabash-3.0.35-saxon-12.4-maven
+      - name: Prepare Calabash and Saxon
+        run: |
+          set -euo pipefail
+          mkdir -p .cache/tools
+          CALABASH_VERSION=3.0.35
+          SAXON_VERSION=12.4
+          SAXON_JAR=".cache/tools/saxon-he-${SAXON_VERSION}.jar"
+          cat > .cache/tools/pom.xml <<'EOF'
+          <project xmlns="http://maven.apache.org/POM/4.0.0"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+            <modelVersion>4.0.0</modelVersion>
+            <groupId>local</groupId>
+            <artifactId>calabash-runner</artifactId>
+            <version>1.0.0</version>
+            <dependencies>
+              <dependency>
+                <groupId>com.xmlcalabash</groupId>
+                <artifactId>app</artifactId>
+                <version>3.0.35</version>
+              </dependency>
+            </dependencies>
+          </project>
+          EOF
+          OUTPUT_FILE="$(pwd)/.cache/tools/classpath.txt"
+          if ! mvn -q -B -f .cache/tools/pom.xml -DincludeScope=runtime -Dmdep.outputFile="$OUTPUT_FILE" \
+            org.apache.maven.plugins:maven-dependency-plugin:3.6.1:build-classpath > .cache/tools/maven.log 2>&1; then
+            echo "Maven failed while building Calabash classpath."
+            tail -n 200 .cache/tools/maven.log || true
+            exit 1
+          fi
+          if [ ! -s "$OUTPUT_FILE" ]; then
+            echo "Calabash classpath not generated."
+            tail -n 200 .cache/tools/maven.log || true
+            exit 1
+          fi
+          echo "Calabash classpath ready."
+          if [ ! -f "$SAXON_JAR" ]; then
+            curl -fL -o "$SAXON_JAR" "https://repo.maven.apache.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar"
+            curl -fL -o "$SAXON_JAR.sha256" "https://repo.maven.apache.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar.sha256"
+            EXPECTED="$(tr -d ' \n' < "$SAXON_JAR.sha256")"
+            if ! echo "$EXPECTED" | grep -Eq '^[0-9a-fA-F]{64}$'; then
+              echo "Invalid Saxon checksum: $EXPECTED"
+              exit 1
+            fi
+            echo "$EXPECTED  $SAXON_JAR" | sha256sum -c -
+          fi
+          echo "Saxon jar ready."
+          CALABASH_CP="$(cat "$OUTPUT_FILE")"
+          echo "XMLCALABASH_CMD=java -cp \"$CALABASH_CP\" com.xmlcalabash.app.Main {PIPELINE}" >> "$GITHUB_ENV"
+          echo "SAXON_JAR=$SAXON_JAR" >> "$GITHUB_ENV"
+      - run: npm ci
+      - run: npm run build
+      - name: Install Trang
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y trang
+      - name: Convert RNG to RNC/XSD
+        run: npm run assets:trang
+      - name: Verify schema conversions
+        run: |
+          test -d build/html/schema
+          test -f build/html/schema/lex-0.rnc
+          test -f build/html/schema/lex-0.xsd
+      - name: Verify build output
+        run: |
+          test -d build/html
+          test -n "$(ls -A build/html)"
+      - name: Post-process HTML for release archive smoke test
+        run: |
+          node scripts/postprocess-html.mjs --mode=release --tag="preview-${GITHUB_SHA::7}" --release-status=historical
+      - name: Build and validate release archives
+        run: npm run release:archives
+
   push_main:
     if: "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && !(github.actor == 'github-actions[bot]' && contains(github.event.head_commit.message, 'chore: update citation metadata')) }}"
     runs-on: ubuntu-latest
@@ -611,46 +710,10 @@ jobs:
           node scripts/postprocess-html.mjs --mode=release --tag="${GITHUB_REF_NAME}" --release-status="${RELEASE_STATUS}"
       - name: Create release archives
         run: |
-          set -euo pipefail
-          rm -f guidelines+schemas.zip guidelines+schemas.tar.gz schemas.zip schemas.tar.gz
-          (
-            cd build/html
-            zip -qr ../../guidelines+schemas.zip .
-            tar -czf ../../guidelines+schemas.tar.gz .
-          )
-          (
-            cd build/html/schema
-            zip -qr ../../../schemas.zip .
-            tar -czf ../../../schemas.tar.gz .
-          )
+          node scripts/release-archives.mjs --create
       - name: Validate release archives
         run: |
-          set -euo pipefail
-          test -f guidelines+schemas.zip
-          test -f guidelines+schemas.tar.gz
-          test -f schemas.zip
-          test -f schemas.tar.gz
-
-          unzip -Z1 guidelines+schemas.zip | grep -Fx 'index.html'
-          unzip -Z1 guidelines+schemas.zip | grep -Fx 'schema/lex-0.rng'
-          tar -tzf guidelines+schemas.tar.gz | grep -E '^\.?/index\.html$'
-          tar -tzf guidelines+schemas.tar.gz | grep -E '^\.?/schema/lex-0\.rng$'
-
-          unzip -Z1 schemas.zip | grep -Fx 'lex-0.rng'
-          unzip -Z1 schemas.zip | grep -Fx 'lex-0.rnc'
-          unzip -Z1 schemas.zip | grep -Fx 'lex-0.xsd'
-          tar -tzf schemas.tar.gz | grep -E '^\.?/lex-0\.rng$'
-          tar -tzf schemas.tar.gz | grep -E '^\.?/lex-0\.rnc$'
-          tar -tzf schemas.tar.gz | grep -E '^\.?/lex-0\.xsd$'
-
-          if unzip -Z1 schemas.zip | grep -Eq '/'; then
-            echo "schemas.zip must contain only schema files at the archive root."
-            exit 1
-          fi
-          if tar -tzf schemas.tar.gz | grep -Ev '(^$|^\.$|^\./?$|^\.?/lex-0\.(rng|rnc|xsd)$)'; then
-            echo "schemas.tar.gz contains unexpected entries."
-            exit 1
-          fi
+          node scripts/release-archives.mjs --validate
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Project: Build Pipeline for TEI Lex-0 Guidelines.
 - `npm run build` full local build (odd + minify + images)
 - `npm run links:check` internal link hygiene for `build/html`
 - `npm run postprocess:html -- --mode=dev` postprocess HTML for dev
+- `npm run release:archives` create + validate `guidelines+schemas.{zip,tar.gz}` and `schemas.{zip,tar.gz}` from current build output
 
 ## Watch mode
 
@@ -54,7 +55,7 @@ Run in separate terminals when iterating:
 
 - Branch from `dev`, always target `dev` in PRs; rebase-only merges to keep `dev` linear.
 - Release to prod by fast-forwarding `main` to `dev` via CLI (`git merge --ff-only origin/dev`).
-- Publish releases from **annotated** tags on `main` (`vX.Y.Z`); tag publish generates `gh-pages/releases/vX.Y.Z/`.
+- Publish releases from **annotated** tags on `main` (`vX.Y.Z`); tag publish generates `gh-pages/releases/vX.Y.Z/` and attaches `guidelines+schemas.{zip,tar.gz}` plus `schemas.{zip,tar.gz}` to the GitHub Release.
 - Never rebase `dev` or `main`; only rebase feature branches and force-push with `--force-with-lease`.
 
 ## Deployment overview
@@ -62,5 +63,6 @@ Run in separate terminals when iterating:
 - `lex-0.org` serves `main` (Vercel project on `vercel-main`).
 - `dev.lex-0.org` serves `dev` (Vercel project on `vercel-dev`).
 - `lex-0.org/releases/vX.Y.Z/` serves GitHub Pages releases via Vercel rewrite.
+- PRs to `dev` also run a non-publishing release-archive smoke test in CI.
 - Release builds are immutable and require annotated tags; if a tag exists, publish fails.
 - HTML output must use relative links (no absolute `/` or `github.io`) or releases will break.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -49,9 +49,9 @@ These branches are artifact-only deployments that contain only the built site.
 
 All deployments are handled in GitHub Actions. High-level triggers:
 
-- Pull requests targeting `dev`: build only; no post-processing; no publish.
+- Pull requests targeting `dev`: build + link hygiene; no deploy. A separate `archive_smoke` job also runs a release-mode archive smoke test without publishing anything.
 - Pushes to `main` and `dev`: build + post-process, then publish to Vercel artifact branches.
-- **Annotated tags** on `main` (e.g., `vX.Y.Z`): build + post-process, then publish to GitHub Pages.
+- **Annotated tags** on `main` (e.g., `vX.Y.Z`): build + post-process, publish to GitHub Pages, and attach custom archives to the GitHub Release.
 - Release metadata for `CITATION.cff` is prepared explicitly during release prep (`npm run release:prepare`), not on every `dev` push.
 - `citation-check` runs on PRs to `dev`/`main`; in branch protection, `dev` currently requires `check_citation` and `pr`.
 
@@ -60,9 +60,10 @@ Common job steps:
 - `npm ci` with caching.
 - Download/cache Calabash + Saxon; set `XMLCALABASH_JAR` and `SAXON_JAR`.
 - Run ODD -> HTML pipeline and asset build.
+- Install Trang and convert generated RNG into RNC and XSD.
 - Fail if `build/html` is missing or empty.
 - Run link hygiene checks on PRs and pushes (skip on tags).
-- TODO: schema generation (RNG + XSD)
+- On the PR-only `archive_smoke` job and on tag releases, post-process in release mode and run `npm run release:archives`.
 
 ### Post-processing
 
@@ -97,6 +98,11 @@ Algolia config:
 - `main` build -> `vercel-main` (repo root).
 - `dev` build -> `vercel-dev` (repo root).
 - Tag build -> `gh-pages/releases/<tag>/`.
+- Tag build -> GitHub Release assets:
+  - `guidelines+schemas.zip`
+  - `guidelines+schemas.tar.gz`
+  - `schemas.zip`
+  - `schemas.tar.gz`
 
 Publishing rules:
 
@@ -104,6 +110,7 @@ Publishing rules:
 - Append commits when publishing to `vercel-main` and `vercel-dev`.
 - For tags, fail if the release folder already exists.
 - `releases/index.html` in `gh-pages` is regenerated on every successful tag publish.
+- Custom release archives are attached to the GitHub Release only; they are not copied into `gh-pages/releases/<tag>/`.
 
 ## Release banner behavior
 
@@ -131,6 +138,7 @@ Use this to validate a deployment:
 - `lex-0.org` serves latest `main` build via Vercel.
 - `dev.lex-0.org` serves latest `dev` build via Vercel.
 - `lex-0.org/releases/vX.Y.Z/` loads via Vercel rewrite with no redirect.
+- The GitHub Release for `vX.Y.Z` includes `guidelines+schemas.{zip,tar.gz}` and `schemas.{zip,tar.gz}`.
 - Assets for releases resolve correctly and stay on `lex-0.org`.
 - Dev and release builds are noindexed.
 

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -7,7 +7,7 @@ Goal: keep `dev` and `main` strictly linear with rebase-only PR merges, publish 
 - Set up [required settings](#required-github-settings) on GitHub
 - **Publish to dev site:** merge PRs into `dev` (rebase-only) → pushing to `dev` triggers deployment to `dev.lex-0.org`.
 - **Publish to production site:** fast-forward `main` to `dev` → pushing to `main` triggers deployment to `lex-0.org`.
-- **Publish an immutable release:** create an **annotated** tag `vX.Y.Z` on `main` and push the tag → GitHub Actions publishes to `gh-pages/releases/vX.Y.Z/` and updates the releases index on `gh-pages`.
+- **Publish an immutable release:** create an **annotated** tag `vX.Y.Z` on `main` and push the tag → GitHub Actions publishes to `gh-pages/releases/vX.Y.Z/`, updates the releases index on `gh-pages`, and attaches `guidelines+schemas.{zip,tar.gz}` plus `schemas.{zip,tar.gz}` to the GitHub Release.
 
 ## Feature branch creation
 
@@ -58,6 +58,10 @@ It checks branch topology, rulesets, workflow wiring, required secrets, tag
 collisions, tag vs `odd/lex-0.odd` edition alignment, and release metadata
 readiness (`date-released` on `origin/dev`).
 
+For a local archive smoke test after you have built and post-processed the site:
+
+- `npm run release:archives`
+
 ### Release automation (preferred)
 
 Use repo-local Node scripts:
@@ -79,7 +83,7 @@ Use the GitHub Actions **release-helper** workflow (`.github/workflows/release-h
 - validates that `CITATION.cff` on `main` already includes `date-released`
 - creates an annotated tag `vX.Y.Z`
 
-Then the normal tag build publishes to `gh-pages/releases/vX.Y.Z/`.
+Then the normal tag build publishes to `gh-pages/releases/vX.Y.Z/` and uploads the four custom release archives to the GitHub Release page for that tag.
 
 ### Release process (manual alternative)
 
@@ -106,11 +110,16 @@ Then the normal tag build publishes to `gh-pages/releases/vX.Y.Z/`.
 
    - Publishes `build/html` to `gh-pages/releases/vX.Y.Z/`
    - Regenerates `gh-pages/releases/index.html`
+   - Uploads `guidelines+schemas.zip`
+   - Uploads `guidelines+schemas.tar.gz`
+   - Uploads `schemas.zip`
+   - Uploads `schemas.tar.gz`
 
 7. Verify:
 
    - `https://lex-0.org/releases/vX.Y.Z/` loads
    - Assets resolve (no `github.io` URLs)
+   - The GitHub Release page for `vX.Y.Z` shows the four custom archive assets in addition to GitHub’s automatic source-code archives
 
 Notes:
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "postprocess:html:dev": "node scripts/postprocess-html.mjs --mode=dev --sitemap=dev",
     "links:check": "node scripts/check-internal-links.mjs",
     "release:doctor": "node scripts/release-doctor.mjs",
+    "release:archives": "node scripts/release-archives.mjs --create --validate",
     "release:prepare": "node scripts/release-prepare.mjs",
     "release:cut": "node scripts/release-cut.mjs",
     "postprocess:watch": "node scripts/watch-postprocess-script.mjs",

--- a/scripts/release-archives.mjs
+++ b/scripts/release-archives.mjs
@@ -1,0 +1,174 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const args = new Set(process.argv.slice(2));
+
+if (args.has("--help")) {
+  console.log("Usage: node scripts/release-archives.mjs [--create] [--validate]");
+  process.exit(0);
+}
+
+const shouldCreate = args.size === 0 || args.has("--all") || args.has("--create");
+const shouldValidate = args.size === 0 || args.has("--all") || args.has("--validate");
+
+if (!shouldCreate && !shouldValidate) {
+  console.error("Nothing to do. Use --create, --validate, or --all.");
+  process.exit(1);
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const buildHtmlDir = path.join(repoRoot, "build", "html");
+const schemaDir = path.join(buildHtmlDir, "schema");
+
+const archives = [
+  {
+    label: "guidelines+schemas",
+    sourceDir: buildHtmlDir,
+    zipPath: path.join(repoRoot, "guidelines+schemas.zip"),
+    tarPath: path.join(repoRoot, "guidelines+schemas.tar.gz"),
+  },
+  {
+    label: "schemas",
+    sourceDir: schemaDir,
+    zipPath: path.join(repoRoot, "schemas.zip"),
+    tarPath: path.join(repoRoot, "schemas.tar.gz"),
+  },
+];
+
+function run(cmd, cmdArgs, options = {}) {
+  const result = spawnSync(cmd, cmdArgs, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+  if (result.status !== 0) {
+    const stderr = (result.stderr || "").trim();
+    throw new Error(`Command failed: ${cmd} ${cmdArgs.join(" ")}${stderr ? `\n${stderr}` : ""}`);
+  }
+  return result.stdout || "";
+}
+
+function assertDir(dir, label) {
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    throw new Error(`${label} not found: ${dir}`);
+  }
+}
+
+function walkFiles(rootDir) {
+  const entries = [];
+
+  function visit(currentDir) {
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      const absolute = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        visit(absolute);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      entries.push(path.relative(rootDir, absolute).split(path.sep).join("/"));
+    }
+  }
+
+  visit(rootDir);
+  return entries.sort();
+}
+
+function normalizeArchiveEntries(raw) {
+  return raw
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => entry.replace(/^\.\//, ""))
+    .filter((entry) => entry !== "." && entry !== "./" && !entry.endsWith("/"))
+    .sort();
+}
+
+function diffEntries(expected, actual) {
+  const expectedSet = new Set(expected);
+  const actualSet = new Set(actual);
+
+  const missing = expected.filter((entry) => !actualSet.has(entry));
+  const extra = actual.filter((entry) => !expectedSet.has(entry));
+
+  return { missing, extra };
+}
+
+function createArchives() {
+  assertDir(buildHtmlDir, "Build output directory");
+  assertDir(schemaDir, "Schema directory");
+
+  for (const archive of archives) {
+    fs.rmSync(archive.zipPath, { force: true });
+    fs.rmSync(archive.tarPath, { force: true });
+    run("zip", ["-qr", archive.zipPath, "."], { cwd: archive.sourceDir });
+    run("tar", ["-czf", archive.tarPath, "."], { cwd: archive.sourceDir });
+    console.log(`Created ${path.basename(archive.zipPath)} and ${path.basename(archive.tarPath)}.`);
+  }
+}
+
+function validateArchives() {
+  assertDir(buildHtmlDir, "Build output directory");
+  assertDir(schemaDir, "Schema directory");
+
+  const expected = new Map(
+    archives.map((archive) => [archive.label, walkFiles(archive.sourceDir)]),
+  );
+
+  for (const required of ["index.html", "schema/lex-0.rng"]) {
+    if (!expected.get("guidelines+schemas").includes(required)) {
+      throw new Error(`Full-site archive source is missing required file: ${required}`);
+    }
+  }
+
+  for (const required of ["lex-0.rng", "lex-0.rnc", "lex-0.xsd"]) {
+    if (!expected.get("schemas").includes(required)) {
+      throw new Error(`Schema archive source is missing required file: ${required}`);
+    }
+  }
+
+  for (const archive of archives) {
+    if (!fs.existsSync(archive.zipPath)) {
+      throw new Error(`Archive not found: ${archive.zipPath}`);
+    }
+    if (!fs.existsSync(archive.tarPath)) {
+      throw new Error(`Archive not found: ${archive.tarPath}`);
+    }
+
+    const expectedEntries = expected.get(archive.label);
+    const zipEntries = normalizeArchiveEntries(run("unzip", ["-Z1", archive.zipPath]));
+    const tarEntries = normalizeArchiveEntries(run("tar", ["-tzf", archive.tarPath]));
+
+    const zipDiff = diffEntries(expectedEntries, zipEntries);
+    if (zipDiff.missing.length || zipDiff.extra.length) {
+      throw new Error(
+        `${path.basename(archive.zipPath)} contents mismatch. Missing: ${zipDiff.missing.join(", ") || "none"}. Extra: ${zipDiff.extra.join(", ") || "none"}.`,
+      );
+    }
+
+    const tarDiff = diffEntries(expectedEntries, tarEntries);
+    if (tarDiff.missing.length || tarDiff.extra.length) {
+      throw new Error(
+        `${path.basename(archive.tarPath)} contents mismatch. Missing: ${tarDiff.missing.join(", ") || "none"}. Extra: ${tarDiff.extra.join(", ") || "none"}.`,
+      );
+    }
+
+    console.log(`Validated ${path.basename(archive.zipPath)} and ${path.basename(archive.tarPath)} (${expectedEntries.length} files).`);
+  }
+}
+
+try {
+  if (shouldCreate) {
+    createArchives();
+  }
+  if (shouldValidate) {
+    validateArchives();
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/release-archives.mjs
+++ b/scripts/release-archives.mjs
@@ -84,7 +84,7 @@ function normalizeArchiveEntries(raw) {
     .map((entry) => entry.trim())
     .filter(Boolean)
     .map((entry) => entry.replace(/^\.\//, ""))
-    .filter((entry) => entry !== "." && entry !== "./" && !entry.endsWith("/"))
+    .filter((entry) => entry !== "" && entry !== "." && entry !== "./" && !entry.endsWith("/"))
     .sort();
 }
 
@@ -146,14 +146,14 @@ function validateArchives() {
     const zipDiff = diffEntries(expectedEntries, zipEntries);
     if (zipDiff.missing.length || zipDiff.extra.length) {
       throw new Error(
-        `${path.basename(archive.zipPath)} contents mismatch. Missing: ${zipDiff.missing.join(", ") || "none"}. Extra: ${zipDiff.extra.join(", ") || "none"}.`,
+        `${path.basename(archive.zipPath)} contents mismatch. Expected ${expectedEntries.length} files, got ${zipEntries.length}. Missing: ${zipDiff.missing.join(", ") || "none"}. Extra: ${zipDiff.extra.join(", ") || "none"}.`,
       );
     }
 
     const tarDiff = diffEntries(expectedEntries, tarEntries);
     if (tarDiff.missing.length || tarDiff.extra.length) {
       throw new Error(
-        `${path.basename(archive.tarPath)} contents mismatch. Missing: ${tarDiff.missing.join(", ") || "none"}. Extra: ${tarDiff.extra.join(", ") || "none"}.`,
+        `${path.basename(archive.tarPath)} contents mismatch. Expected ${expectedEntries.length} files, got ${tarEntries.length}. Missing: ${tarDiff.missing.join(", ") || "none"}. Extra: ${tarDiff.extra.join(", ") || "none"}.`,
       );
     }
 


### PR DESCRIPTION
- **ci: publish release archives**
  - package guidelines and schema outputs into zip/tar
  - validate and upload assets to the GitHub release tag
  

- **ci: add release archive smoke tests**
  - add archive_smoke job to PR workflow
  - replace manual archive commands with script
  - document release archive process across guides
  