### PR TITLE
fix missing attributes on gloss

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,0 +1,162 @@
+# Issue Labels Proposal
+
+This document proposes a lightweight label system for `BCDH/tei-lex-0` that fits TEI Lex-0 guidelines work better than the default GitHub software-development labels.
+
+The names below are intentionally short. The prefix carries the classification dimension; the rest should stay compact.
+
+## Principles
+
+- Use a small number of labels.
+- Keep label dimensions separate with prefixes.
+- Default to at most two labels per issue:
+  - one `kind:*`
+  - one `area:*`
+- Use milestones, not labels, for release targeting such as `v0.9.6`.
+
+## Recommended label dimensions
+
+### `kind:*`
+
+Use exactly one of these on most issues.
+
+- `kind:schema`
+  - Changes to allowed elements, attributes, values, or content models.
+- `kind:guidelines`
+  - Clarify, write, expand, revise or restructure guideline prose or examples.
+- `kind:bug`
+  - Spec/example mismatch, broken validation, or internal inconsistency.
+- `kind:tooling`
+  - Build, CI, deployment, website, editor integration, or repo workflow.
+- `kind:release`
+  - Release assets, website publication, archived versions, and historical releases.
+
+### `area:*`
+
+Use one of these when the issue has a clear topical area.
+
+- `area:front-back`
+  - Front matter, back matter, title pages, layout elements, facsimile-related structure.
+- `area:cross-references`
+  - `xr`, `ref`, related-entry structures, labels, and linking patterns.
+- `area:grammar`
+  - `gram`, `gramGrp`, valency, collocates, grammatical categories and values.
+- `area:header`
+  - `teiHeader`, bibliographic metadata, publication/source/revision description.
+- `area:entry-structure`
+  - Entry/sense/def/cit/quote content models and inline lexicographic structures, excluding form-specific modeling.
+- `area:forms`
+  - `form`, `orth`, `pron`, lemma and inflected/variant/derived form modeling.
+
+## `status:*` labels
+
+These are worth keeping:
+
+- `status:duplicate`
+  - This issue or pull request already exists.
+- `status:invalid`
+  - This doesn't seem right.
+- `status:wontfix`
+  - This will not be worked on.
+- `status:help-wanted`
+  - Extra attention is needed.
+- `status:good-first-issue`
+  - Good for newcomers.
+
+These should not be used as the primary taxonomy for this repository:
+
+- `bug`
+- `enhancement`
+- `documentation`
+- `question`
+
+## Colors
+
+Use a unique color for every label. No two labels should share the same color.
+
+### `kind:*`
+
+- `kind:schema` `#0052CC`
+- `kind:guidelines` `#5319E7`
+- `kind:bug` `#D73A4A`
+- `kind:tooling` `#0E8A16`
+- `kind:release` `#FF9F1C`
+
+### `area:*`
+
+- `area:front-back` `#BFD4F2`
+- `area:cross-references` `#006B75`
+- `area:grammar` `#F9D0C4`
+- `area:header` `#D4C5F9`
+- `area:entry-structure` `#BFE5BF`
+- `area:forms` `#F7C6C7`
+
+### `status:*`
+
+- `status:duplicate` `#C5C9D1`
+- `status:invalid` `#E4E669`
+- `status:wontfix` `#6A737D`
+- `status:help-wanted` `#A371F7`
+- `status:good-first-issue` `#1B9AAA`
+
+## Migration Plan
+
+### Rename existing labels
+
+- `duplicate` -> `status:duplicate`
+- `invalid` -> `status:invalid`
+- `wontfix` -> `status:wontfix`
+- `help wanted` -> `status:help-wanted`
+- `good first issue` -> `status:good-first-issue`
+
+These should keep their current GitHub meanings and descriptions.
+
+### Create new labels
+
+- `kind:schema`
+- `kind:guidelines`
+- `kind:bug`
+- `kind:tooling`
+- `kind:release`
+- `area:front-back`
+- `area:cross-references`
+- `area:grammar`
+- `area:header`
+- `area:entry-structure`
+- `area:forms`
+
+### Delete or stop using
+
+- `bug`
+- `enhancement`
+- `documentation`
+- `question`
+
+## Usage examples
+
+- `#284` Make previous versions of schema available on the website and in the repository
+  - `kind:release`
+
+- `#277` Allow `<lbl>` inside `<def>` (and other phrase-level contexts)
+  - `kind:schema`
+  - `area:entry-structure`
+
+- `#117` Mupltiple references within one `<xr>` element, or multliple `<xr>` elements?
+  - `kind:guidelines`
+  - `area:cross-references`
+
+- `#105` `.rng` file incorrectly flags `authority` tag as not allowed within `publicationStmt`
+  - `kind:bug`
+  - `area:header`
+
+- `#98` More elements for encoding front/back matter
+  - `kind:schema`
+  - `area:front-back`
+
+## Working rule
+
+Recommended default:
+
+1. Assign one `kind:*` label.
+2. Assign one `area:*` label if there is a clear topical area.
+
+This should keep the issue tracker readable without mixing unrelated classification systems.

--- a/odd/includes/60__specification.xml
+++ b/odd/includes/60__specification.xml
@@ -320,7 +320,7 @@
             </content>
         </elementSpec>
         <elementSpec ident="gloss" mode="change">
-            <classes>
+            <classes mode="change">
                 <memberOf key="model.lexEmphLike" mode="add"/>
             </classes>
         </elementSpec>

--- a/odd/lex-0.odd
+++ b/odd/lex-0.odd
@@ -173,13 +173,12 @@
             <editionStmt>
                 <!--in the dev branch, make sure to add the "-dev" suffix to the @n-->
                 <!--make sure to remove the dev suffix when publishing a new release-->
-                <edition n="0.9.6-dev"/>
+                <edition n="0.9.6-dev" />
             </editionStmt>
-
             <publicationStmt>
                 <authority>DARIAH Working Group on Lexical Resources</authority>
-                <date when="2026"/>
-                <ptr target="https://lex-0.org"/>
+                <date when="2026" />
+                <ptr target="https://lex-0.org" />
             </publicationStmt>
             <sourceDesc>
                 <p>Born digital</p>
@@ -209,43 +208,41 @@
         <revisionDesc>
             <listChange>
                 <listChange n="0.9.6-dev" xml:id="v.0.9.6-dev">
-                    <change when="2026-02-08" type="docs">Set up v.0.9.6-dev.</change>
+                    <change when="2026-04-01" type="spec">Fixed missing attributes on <gi>gloss</gi> as per <ref
+                            target="https://github.com/BCDH/tei-lex-0/issues/289"
+                        >#289</ref></change>
+                    <change type="docs">Set up v.0.9.6-dev.</change>
                     <change type="spec">Reintroduced <gi>ruby</gi> annotation support as per <ref
                             target="https://github.com/BCDH/tei-lex-0/issues/120"
-                            >#120</ref></change>
+                        >#120</ref></change>
                 </listChange>
                 <listChange n="0.9.5" xml:id="v0.9.5" corresp="releases/v0.9.5">
                     <change when="2026-02-08" type="docs">Added documentation on encoding condensed
                         forms a là "leleti (sě)".</change>
                     <change type="spec">Added <ref target="#TEI.model.languageProfile"
-                            >model.languageProfile</ref> to better structure <gi>language</gi> as
-                        per <ref target="https://github.com/DARIAH-ERIC/lexicalresources/issues/245"
-                            >#245</ref>.</change>
-                    <change type="spec">Added <gi>measure</gi> (to be used, for instance, within
-                            <gi>extent</gi> in <gi>fileDesc</gi> as per <ref
+                        >model.languageProfile</ref> to better structure <gi>language</gi> as per <ref target="https://github.com/DARIAH-ERIC/lexicalresources/issues/245"
+                        >#245</ref>.</change>
+                    <change type="spec">Added <gi>measure</gi> (to be used, for instance, within <gi>extent</gi> in <gi>fileDesc</gi> as per <ref
                             target="https://github.com/DARIAH-ERIC/lexicalresources/issues/257"
-                            >#257</ref>.</change>
-                    <change type="xproc">Added a temporary step to fix <att>xml:base</att> and
-                            <att>xml:lang</att> issues in xincluded examples as per <ref
+                        >#257</ref>.</change>
+                    <change type="xproc">Added a temporary step to fix <att>xml:base</att> and <att>xml:lang</att> issues in xincluded examples as per <ref
                             target="https://github.com/DARIAH-ERIC/lexicalresources/issues/256"
-                            >#256</ref></change>
+                        >#256</ref></change>
                     <change type="spec">Deprecated <code rend="language-xpath"
-                            >gram[@type="government"]</code> in favor of <code rend="language-xpath"
-                            >gram[@type="construction"]</code> as per <ref
+                        >gram[@type="government"]</code> in favor of <code rend="language-xpath"
+                        >gram[@type="construction"]</code> as per <ref
                             target="https://github.com/DARIAH-ERIC/lexicalresources/issues/254"
-                            >#254</ref></change>
-                    <change type="spec">Refactored model classes to fix XSD UPA violations as per
-                            <ref target="https://github.com/DARIAH-ERIC/lexicalresources/issues/223"
-                            >#223</ref>.</change>
+                        >#254</ref></change>
+                    <change type="spec">Refactored model classes to fix XSD UPA violations as per <ref target="https://github.com/DARIAH-ERIC/lexicalresources/issues/223"
+                        >#223</ref>.</change>
                     <change type="docs">Minor corrections in the documentation</change>
                     <change type="docs">Introduced the labeling of P5 and Lex-0 examples in the
                         specification to avoid confusion</change>
                     <change type="docs">Added a secion on documenting <ref
                             target="#language-profile">language profiles</ref> to the <hi
                             rend="italic">Guidelines</hi></change>
-                    <change type="spec">Included <gi>listPlace</gi> to be used in
-                            <gi>settingDesc</gi> as part of <ref target="#TEI.model.languageProfile"
-                            >model.languageProfile</ref></change>
+                    <change type="spec">Included <gi>listPlace</gi> to be used in <gi>settingDesc</gi> as part of <ref target="#TEI.model.languageProfile"
+                        >model.languageProfile</ref></change>
                 </listChange>
                 <listChange n="0.9.4" corresp="releases/v0.9.4/">
                     <change when="2024-05-12" type="xproc">fix documentation build on macOS and
@@ -260,110 +257,84 @@
                         <hi rend="italic">must</hi> contain a <gi>term</gi></change>
                     <change type="spec">switch to using the external TEI add-on in oXygen when
                         generating schema and documentation</change>
-                    <change type="spec">fix the mismatch in <gi>usg</gi> types between the
-                        specification and documentation (use <code>temporal</code> instead of
-                            <code>time</code>
+                    <change type="spec">fix the mismatch in <gi>usg</gi> types between the specification and documentation (use <code>temporal</code> instead of <code>time</code>
                     </change>
-                    <change type="spec">require <gi>listBibl</gi> in <gi>sourceDesc</gi> with three
-                        suggested type values: <code>dictionaries</code>, <code>corpora</code> and
-                            <code>literature</code></change>
+                    <change type="spec">require <gi>listBibl</gi> in <gi>sourceDesc</gi> with three suggested type values: <code>dictionaries</code>, <code>corpora</code> and <code>literature</code></change>
                 </listChange>
                 <listChange n="0.9.2">
                     <change when="2023-04-22" type="xproc">switch to using oXygen's TEI framework
                         when generating schema and documentation</change>
-                    <change type="spec">allow <gi>list</gi> and <gi>item</gi> because lists feature
-                        prominently in dictionary front matter</change>
+                    <change type="spec">allow <gi>list</gi> and <gi>item</gi> because lists feature prominently in dictionary front matter</change>
                     <change type="spec">introduce <ref target="#TEI.model.lexicalInter"
-                            >model.lexicalInter</ref> (based on <ref target="#TEI.model.inter"
-                            >model.inter</ref>), <ref target="#TEI.model.lexicalPhrase"
-                            >model.lexicalPhrase</ref> (based on <ref target="#TEI.model.phrase"
-                            >model.phrase</ref>) and <ref target="#TEI.macro.lexicalParaContent"
-                            >macro.lexicalParaContent</ref> (based on <ref
-                            target="#TEI.macro.paraContent">macro.paraContent</ref>) to make it
-                        easier to simplify the content model of various dictionary elements</change>
+                        >model.lexicalInter</ref> (based on <ref target="#TEI.model.inter"
+                        >model.inter</ref>), <ref target="#TEI.model.lexicalPhrase"
+                        >model.lexicalPhrase</ref> (based on <ref target="#TEI.model.phrase"
+                        >model.phrase</ref>) and <ref target="#TEI.macro.lexicalParaContent"
+                        >macro.lexicalParaContent</ref> (based on <ref
+                            target="#TEI.macro.paraContent">macro.paraContent</ref>) to make it easier to simplify the content model of various dictionary elements</change>
                     <change type="spec">remove <ref target="#TEI.model.listLike"
-                            >model.listLike</ref> from <ref target="#TEI.model.lexicalInter"
-                            >model.lexicalInter</ref></change>
+                        >model.listLike</ref> from <ref target="#TEI.model.lexicalInter"
+                        >model.lexicalInter</ref></change>
                     <change type="html">link version number in the menu to revision history</change>
-                    <change type="spec">allow <gi>abbr</gi> and <gi>expan</gi> so that they can be
-                        used in lists of abbreviations in dictionary front matter</change>
-                    <change type="spec">introduced <code>valency</code> as a suggested value in
-                            <code rend="language-xpath">gram[@type="valency"]</code></change>
+                    <change type="spec">allow <gi>abbr</gi> and <gi>expan</gi> so that they can be used in lists of abbreviations in dictionary front matter</change>
+                    <change type="spec">introduced <code>valency</code> as a suggested value in <code rend="language-xpath">gram[@type="valency"]</code></change>
                     <change type="spec">introduced <code rend="language-xpath"
-                            >gram[@type="government"]</code> and clarified the difference from <code
+                        >gram[@type="government"]</code> and clarified the difference from <code
                             rend="language-xpath">gram[@type="colloc"]</code>. See sections on <ref
                             target="#typology-of-gram">Typology of <code>gram</code></ref> and <ref
                             target="#collocates">Collocates</ref></change>
-                    <change type="spec">made <code rend="language-xpath">@type</code> mandatory on
-                            <gi>TEI</gi></change>
-                    <change type="spec">add <gi>principal</gi> and <gi>affiliation</gi> for more
-                        robust metadata in the <gi>teiHeader</gi></change>
+                    <change type="spec">made <code rend="language-xpath">@type</code> mandatory on <gi>TEI</gi></change>
+                    <change type="spec">add <gi>principal</gi> and <gi>affiliation</gi> for more robust metadata in the <gi>teiHeader</gi></change>
                 </listChange>
                 <listChange n="0.9.1">
                     <change when="2021-03-24" type="html">fix namespace issues in html
                         output</change>
-                    <change type="docs">add new examples to the <ref target="#header">Header</ref>
-                        section</change>
+                    <change type="docs">add new examples to the <ref target="#header">Header</ref> section</change>
                     <change type="docs">add section on <ref target="#HierarchicalUsageLabels"
-                            >hierarchichal usage labels</ref></change>
-                    <change type="spec">allow <gi>taxonomy</gi>, <gi>category</gi> and
-                            <gi>catDesc</gi> in <gi>classDecl</gi>
+                        >hierarchichal usage labels</ref></change>
+                    <change type="spec">allow <gi>taxonomy</gi>, <gi>category</gi> and <gi>catDesc</gi> in <gi>classDecl</gi>
                     </change>
-                    <change type="docs">move the <ref target="#specification">specification</ref> to
-                        a different webpage for quicker loading</change>
+                    <change type="docs">move the <ref target="#specification">specification</ref> to a different webpage for quicker loading</change>
                 </listChange>
                 <listChange n="0.9.0">
                     <change when="2021-09-26" type="docs">add section on <ref target="#header">TEI
                             Header</ref></change>
                     <change type="docs">correction of various misspellings</change>
-                    <change type="spec">add <gi>monogr</gi> (needed for
-                        <gi>biblStruct</gi>)</change>
-                    <change type="spec">add <gi>forename</gi> and <gi>surname</gi> for more
-                        fine-grained bibliographic information</change>
+                    <change type="spec">add <gi>monogr</gi> (needed for <gi>biblStruct</gi>)</change>
+                    <change type="spec">add <gi>forename</gi> and <gi>surname</gi> for more fine-grained bibliographic information</change>
                     <change type="spec">add <gi>editorialDecl</gi></change>
-                    <change type="spec">add <gi>email</gi> to make possible contact information in
-                        the header</change>
-                    <change type="spec">require <gi>availability</gi> in <gi>publicationStmt</gi> to
-                        provide <gi>licence</gi></change>
+                    <change type="spec">add <gi>email</gi> to make possible contact information in the header</change>
+                    <change type="spec">require <gi>availability</gi> in <gi>publicationStmt</gi> to provide <gi>licence</gi></change>
                     <change type="spec">make <gi>sourceDesc</gi> optional</change>
-                    <change type="spec">allow only <gi>biblStruct</gi> in
-                        <gi>sourceDesc</gi></change>
+                    <change type="spec">allow only <gi>biblStruct</gi> in <gi>sourceDesc</gi></change>
                     <change type="spec">make <ref target="#TEI.model.publicationStmtPart.agency"
-                            >model.publicationStmtPart.agency</ref> unbound to allow both
-                            <gi>publisher</gi> and <gi>authority</gi> in
-                        <gi>publicationStmt</gi></change>
-                    <change type="spec">add <att>role</att> to <gi>authority</gi> with suggested
-                        values: <val>funder</val>, <val>sponsor</val>,
-                        <val>rightsHolder</val></change>
-                    <change type="spec">require <gi>language</gi>, <gi>langUsage</gi> and
-                            <gi>profileDesc</gi></change>
-                    <change type="spec">add <att>role</att> to <gi>language</gi> with a closed list
-                        of values: <val>objectLanguage</val>, <val>workingLanguage</val>,
-                            <val>sourceLanguage</val>, <val>targetLanguage</val></change>
-
+                        >model.publicationStmtPart.agency</ref> unbound to allow both <gi>publisher</gi> and <gi>authority</gi> in <gi>publicationStmt</gi></change>
+                    <change type="spec">add <att>role</att> to <gi>authority</gi> with suggested values: <val>funder</val>, <val>sponsor</val>, <val>rightsHolder</val></change>
+                    <change type="spec">require <gi>language</gi>, <gi>langUsage</gi> and <gi>profileDesc</gi></change>
+                    <change type="spec">add <att>role</att> to <gi>language</gi> with a closed list of values: <val>objectLanguage</val>, <val>workingLanguage</val>, <val>sourceLanguage</val>, <val>targetLanguage</val></change>
                 </listChange>
             </listChange>
         </revisionDesc>
     </teiHeader>
     <text>
         <front>
-            <xi:include href="includes/00__index.xml" parse="xml" xpointer="home"/>
+            <xi:include href="includes/00__index.xml" parse="xml" xpointer="home" />
         </front>
         <body>
-            <xi:include href="includes/05__header.xml" parse="xml" xpointer="header"/>
-            <xi:include href="includes/10__entries.xml" parse="xml" xpointer="entries"/>
-            <xi:include href="includes/15__forms.xml" parse="xml" xpointer="forms"/>
-            <xi:include href="includes/20__senses.xml" parse="xml" xpointer="senses"/>
-            <xi:include href="includes/25__translations.xml" parse="xml" xpointer="translations"/>
+            <xi:include href="includes/05__header.xml" parse="xml" xpointer="header" />
+            <xi:include href="includes/10__entries.xml" parse="xml" xpointer="entries" />
+            <xi:include href="includes/15__forms.xml" parse="xml" xpointer="forms" />
+            <xi:include href="includes/20__senses.xml" parse="xml" xpointer="senses" />
+            <xi:include href="includes/25__translations.xml" parse="xml" xpointer="translations" />
             <xi:include href="includes/30__cross-references.xml" parse="xml"
-                xpointer="cross-references"/>
-            <xi:include href="includes/35__usage.xml" parse="xml" xpointer="usage"/>
-            <xi:include href="includes/40__etymology.xml" parse="xml" xpointer="etymology"/>
-            <xi:include href="includes/45__patterns.xml" parse="xml" xpointer="patterns"/>
-            <xi:include href="includes/60__specification.xml" parse="xml" xpointer="specification"/>
-            <xi:include href="includes/70__community.xml" parse="xml" xpointer="community"/>
-            <xi:include href="includes/85__bibliography.xml" parse="xml" xpointer="bibliography"/>
-            <xi:include href="includes/80__faq.xml" parse="xml" xpointer="faq"/>
+                xpointer="cross-references" />
+            <xi:include href="includes/35__usage.xml" parse="xml" xpointer="usage" />
+            <xi:include href="includes/40__etymology.xml" parse="xml" xpointer="etymology" />
+            <xi:include href="includes/45__patterns.xml" parse="xml" xpointer="patterns" />
+            <xi:include href="includes/60__specification.xml" parse="xml" xpointer="specification" />
+            <xi:include href="includes/70__community.xml" parse="xml" xpointer="community" />
+            <xi:include href="includes/85__bibliography.xml" parse="xml" xpointer="bibliography" />
+            <xi:include href="includes/80__faq.xml" parse="xml" xpointer="faq" />
             <!--   <xi:include href="parts/90__annex_A.xml" parse="xml" xpointer="annex_A"/>
             <xi:include href="parts/90__annex_B.xml" parse="xml" xpointer="annex_B"/>-->
         </body>


### PR DESCRIPTION
- **docs: propose issue label taxonomy**
  - Outline kind, area, and status label prefixes and colors
  - Provide migration steps for renaming, adding, retiring labels
  

- **fix(odd): missing attributes on gloss as per #289**
  - Set mode change on specification classes include
  